### PR TITLE
added features, updated docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ $.previewImage({
 	/* The following set of options are the ones that should most often be changed
 	   by passing an options object into this method.
 	*/
-	'xOffset': 10,    // the x offset from the cursor where the image will be overlayed.
-	'yOffset': 10,    // the y offset from the cursor where the image will be overlayed.
+	'xOffset': 20,    // the x offset from the cursor where the image will be overlayed.
+	'yOffset': 20,    // the y offset from the cursor where the image will be overlayed.
 	'fadeIn': 'fast', // speed in ms to fade in, 'fast' and 'slow' also supported.
 	'maxHeight': 400, // limit the height of the preview image in pixels
 	'css': {          // css to use, may also be set to false.

--- a/README.md
+++ b/README.md
@@ -39,27 +39,27 @@ Another example:
 If you don't like the defaults, you can optionally change any or all of them like:
 ``` javascript
 $.previewImage({
-			/* The following set of options are the ones that should most often be changed
-			   by passing an options object into this method.
-			*/
-			'xOffset': 10,    // the x offset from the cursor where the image will be overlayed.
-			'yOffset': 10,   // the y offset from the cursor where the image will be overlayed.
-			'fadeIn': 'fast', // speed in ms to fade in, 'fast' and 'slow' also supported.
-			'maxHeight': 400,
-			// css to use, may also be set to false.
-			'css': {
-				'padding': '8px',
-				'border': '1px solid #ccc',
-				'background-color': '#fff',
-				'z-index': '2000',
-			},
+	/* The following set of options are the ones that should most often be changed
+	   by passing an options object into this method.
+	*/
+	'xOffset': 10,    // the x offset from the cursor where the image will be overlayed.
+	'yOffset': 10,   // the y offset from the cursor where the image will be overlayed.
+	'fadeIn': 'fast', // speed in ms to fade in, 'fast' and 'slow' also supported.
+	'maxHeight': 400,
+	// css to use, may also be set to false.
+	'css': {
+		'padding': '8px',
+		'border': '1px solid #ccc',
+		'background-color': '#fff',
+		'z-index': '2000',
+	},
 
-			/* The following options should normally not be changed - they are here for
-			   cases where this plugin causes problems with other plugins/javascript.
-			*/
-			'eventSelector': '[data-preview-image]', // the selector for binding mouse events.
-			'dataKey': 'previewImage', // the key to the link data, should match the above value.
-			'overlayId': 'preview-image-plugin-overlay', // the id of the overlay that will be created.
+	/* The following options should normally not be changed - they are here for
+	   cases where this plugin causes problems with other plugins/javascript.
+	*/
+	'eventSelector': '[data-preview-image]', // the selector for binding mouse events.
+	'dataKey': 'previewImage', // the key to the link data, should match the above value.
+	'overlayId': 'preview-image-plugin-overlay', // the id of the overlay that will be created.
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -43,11 +43,10 @@ $.previewImage({
 	   by passing an options object into this method.
 	*/
 	'xOffset': 10,    // the x offset from the cursor where the image will be overlayed.
-	'yOffset': 10,   // the y offset from the cursor where the image will be overlayed.
+	'yOffset': 10,    // the y offset from the cursor where the image will be overlayed.
 	'fadeIn': 'fast', // speed in ms to fade in, 'fast' and 'slow' also supported.
-	'maxHeight': 400,
-	// css to use, may also be set to false.
-	'css': {
+	'maxHeight': 400, // limit the height of the preview image in pixels
+	'css': {          // css to use, may also be set to false.
 		'padding': '8px',
 		'border': '1px solid #ccc',
 		'background-color': '#fff',

--- a/README.md
+++ b/README.md
@@ -39,13 +39,27 @@ Another example:
 If you don't like the defaults, you can optionally change any or all of them like:
 ``` javascript
 $.previewImage({
-   'xOffset': 10,  // x-offset from cursor
-   'yOffset': 10,  // y-offset from cursor
-   'fadeIn': 1000, // delay in ms. to display the preview
-   'css': {        // the following css will be used when rendering the preview image.
-      'padding': '20px',
-      'border': '5px solid black'
-   }
+			/* The following set of options are the ones that should most often be changed
+			   by passing an options object into this method.
+			*/
+			'xOffset': 10,    // the x offset from the cursor where the image will be overlayed.
+			'yOffset': 10,   // the y offset from the cursor where the image will be overlayed.
+			'fadeIn': 'fast', // speed in ms to fade in, 'fast' and 'slow' also supported.
+			'maxHeight': 400,
+			// css to use, may also be set to false.
+			'css': {
+				'padding': '8px',
+				'border': '1px solid #ccc',
+				'background-color': '#fff',
+				'z-index': '2000',
+			},
+
+			/* The following options should normally not be changed - they are here for
+			   cases where this plugin causes problems with other plugins/javascript.
+			*/
+			'eventSelector': '[data-preview-image]', // the selector for binding mouse events.
+			'dataKey': 'previewImage', // the key to the link data, should match the above value.
+			'overlayId': 'preview-image-plugin-overlay', // the id of the overlay that will be created.
 });
 ```
 
@@ -57,3 +71,4 @@ $.previewImage({css: false});
 History
 -------
 * **1.0** Initial commit
+* **1.1** Preview won't display image out of window bounds, it's instead rendered to the left and/or top of the mouse cursor, respecting offsets.

--- a/preview-image.js
+++ b/preview-image.js
@@ -1,67 +1,97 @@
 /**
  * preview-image.js
- * version 1.0
+ * version 1.1
  * Eric Olson
+ *
  * https://github.com/zpalffy/preview-image-jquery
- * 
+ *
  * License: MIT - http://opensource.org/licenses/MIT
- * Original: http://cssglobe.com/easiest-tooltip-and-image-preview-using-jquery/ 
+ * Original: http://cssglobe.com/easiest-tooltip-and-image-preview-using-jquery/
  *     by Alen Grakalic (http://cssglobe.com)
  */
  (function($) {
 	$.previewImage = function(options) {
-	    var element = $(document);
-	    var namespace = '.previewImage';
-	    	
+		var element = $(document);
+		var namespace = '.previewImage';
+
 		var opts = $.extend({
-			/* The following set of options are the ones that should most often be changed 
+			/* The following set of options are the ones that should most often be changed
 			   by passing an options object into this method.
 			*/
-			'xOffset': 20,    // the x offset from the cursor where the image will be overlayed.
-			'yOffset': -20,   // the y offset from the cursor where the image will be overlayed.			
+			'xOffset': 10,    // the x offset from the cursor where the image will be overlayed.
+			'yOffset': 10,    // the y offset from the cursor where the image will be overlayed.
 			'fadeIn': 'fast', // speed in ms to fade in, 'fast' and 'slow' also supported.
-			'css': {          // css to use, may also be set to false.
+			'maxHeight': 400, // limit the height of the preview image in pixels
+			// css to use, may also be set to false.
+			'css': {
 				'padding': '8px',
-				'border': '1px solid gray',
-				'background-color': '#fff'
+				'border': '1px solid #ccc',
+				'background-color': '#fff',
+				'z-index': '2000',
 			},
-			
-			/* The following options should normally not be changed - they are here for 
+
+			/* The following options should normally not be changed - they are here for
 			   cases where this plugin causes problems with other plugins/javascript.
 			*/
 			'eventSelector': '[data-preview-image]', // the selector for binding mouse events.
 			'dataKey': 'previewImage', // the key to the link data, should match the above value.
 			'overlayId': 'preview-image-plugin-overlay', // the id of the overlay that will be created.
 		}, options);
-		
+
 		// unbind any previous event listeners:
 		element.off(namespace);
-			
+
 		element.on('mouseover' + namespace, opts.eventSelector, function(e) {
-			var p = $('<p>').attr('id', opts.overlayId).css('position', 'absolute')
+			var img = $('<img>')
+				.attr('src', $(this).data(opts.dataKey))
+				.css('max-height', opts.maxHeight || 'initial')
+
+			var p = $('<p>')
+				.attr('id', opts.overlayId)
+				.css('position', 'absolute')
 				.css('display', 'none')
-				.append($('<img>').attr('src', $(this).data(opts.dataKey)));
+				.append(img);
 			if (opts.css) p.css(opts.css);
-			
 			$('body').append(p);
-			
-			p.css("top", (e.pageY + opts.yOffset) + "px").css("left", 
-				(e.pageX + opts.xOffset) + "px").fadeIn(opts.fadeIn);		
+
+			img.on('load', function() {
+				var c = getCoordinates(e, this.width, this.height);
+				p.data('img', this);
+				p.css("left", c.x + "px")
+				.css("top", c.y + "px")
+				.fadeIn(opts.fadeIn);
+			})
 		});
-		
+
 
 		element.on('mouseout' + namespace, opts.eventSelector, function() {
 			$('#' + opts.overlayId).remove();
 		});
-		
+
 		element.on('mousemove' + namespace, opts.eventSelector, function(e) {
-			$('#' + opts.overlayId).css("top", (e.pageY + opts.yOffset) + "px")
-				.css("left", (e.pageX + opts.xOffset) + "px");
+			var p = $('#' + opts.overlayId),
+				img = p.data('img');
+			if(!img) return;
+
+			var c = getCoordinates(e, img.width, img.height);
+			p.css("left", c.x + "px")
+			 .css("top", c.y + "px");
 		});
-		
+
+		function getCoordinates(e, width, height) {
+			var currentX = e.pageX,
+				currentY = e.pageY;
+			return {
+				x: currentX + width + opts.xOffset <= window.innerWidth ?
+					currentX + opts.xOffset : currentX - width - opts.xOffset,
+				y: currentY + height + opts.yOffset <= window.innerHeight ?
+					currentY + opts.yOffset: currentY - height - opts.yOffset
+			}
+		}
+
 		return this;
 	};
-	
+
 	// bind with defaults so that the plugin can be used immediately if defaults are taken:
 	$.previewImage();
 })(jQuery);

--- a/preview-image.js
+++ b/preview-image.js
@@ -18,8 +18,8 @@
 			/* The following set of options are the ones that should most often be changed
 			   by passing an options object into this method.
 			*/
-			'xOffset': 10,    // the x offset from the cursor where the image will be overlayed.
-			'yOffset': 10,    // the y offset from the cursor where the image will be overlayed.
+			'xOffset': 20,    // the x offset from the cursor where the image will be overlayed.
+			'yOffset': 20,    // the y offset from the cursor where the image will be overlayed.
 			'fadeIn': 'fast', // speed in ms to fade in, 'fast' and 'slow' also supported.
 			'maxHeight': 400, // limit the height of the preview image in pixels
 			// css to use, may also be set to false.


### PR DESCRIPTION
script:
- Preview won't display image out of window bounds, it's instead rendered to the left and/or top of the mouse cursor, respecting offsets.
- added parameter `maxHeight` that limits the height of the preview image

docs:
- updated parameter defaults to work better with flipping image preview that is out of window bounds
- added every possible parameter to the readme.md so it better documents all the features